### PR TITLE
dictset.__getattr__ handles missing attribute correctly now.

### DIFF
--- a/nefertari/utils/dictset.py
+++ b/nefertari/utils/dictset.py
@@ -27,7 +27,10 @@ class dictset(dict):
         return dictset([[k, v] for k, v in self.items() if k not in only])
 
     def __getattr__(self, key):
-        return self[key]
+        if key in self:
+            return self[key]
+        else:
+            raise AttributeError("No such attribute: %s" % key)
 
     def __setattr__(self, key, val):
         self[key] = val


### PR DESCRIPTION
	modified:   nefertari/utils/dictset.py

`dictset` implemented method `__getattrib__` incompletely and was failing when missing attribute name was requested.

Corrected code raises `AttributeError`.

This error caused `ramses_example` to fail on installation with `simplejson` installed without speedups.